### PR TITLE
import errno, os for line 160

### DIFF
--- a/dbxfs/cachingfs.py
+++ b/dbxfs/cachingfs.py
@@ -262,7 +262,7 @@ class _Directory(object):
                 else:
                     self._refreshed = False
 
-                assert stat_num == new_stat_num or dir_num != new_dir_nume, (
+                assert stat_num == new_stat_num or dir_num != new_dir_num, (
                     "If stat for directoy was invalidated, entries must be as well"
                 )
 

--- a/dbxfs/safefs_glue.py
+++ b/dbxfs/safefs_glue.py
@@ -17,6 +17,8 @@
 
 import collections
 import contextlib
+import errno
+import os
 import subprocess
 
 from userspacefs.path_common import Path


### PR DESCRIPTION
__raise OSError(errno.EXDEV, os.strerror(errno.EXDEV))__

[flake8](http://flake8.pycqa.org) testing of https://github.com/rianhunter/dbxfs on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./dbxfs/cachingfs.py:265:63: F821 undefined name 'new_dir_nume'
                assert stat_num == new_stat_num or dir_num != new_dir_nume, (
                                                              ^
./dbxfs/cachingfs.py:1446:73: F821 undefined name 'e'
            raise OSError(errno.EEXIST, os.strerror(errno.EEXIST)) from e
                                                                        ^
./dbxfs/safefs_glue.py:158:27: F821 undefined name 'errno'
            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV))
                          ^
./dbxfs/safefs_glue.py:158:40: F821 undefined name 'os'
            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV))
                                       ^
./dbxfs/safefs_glue.py:158:52: F821 undefined name 'errno'
            raise OSError(errno.EXDEV, os.strerror(errno.EXDEV))
                                                   ^
5     F821 undefined name 'new_dir_nume'
5
```