### PR TITLE
added --no-cache option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="dbxfs",
-    version='1.0.39',
+    version='1.0.40',
     author="Rian Hunter",
     author_email="rian@alum.mit.edu",
     description="User-space file system for Dropbox",


### PR DESCRIPTION
...to handle cases where dbxfs eats nearly all the filesystem (e.g. when copying data from Dropbox exceeding internal storage capacity to an externally mounted drive). 

I had a >1TB folder on Dropbox to back up locally on an external drive, and since dbxfs caches file by default on the system drive, my computer was quickly running low on available disk space. 
This new option disables the cache on the system drive only for the current session, i.e. you have to specify `--no-cache` each time you mount the drive to have the feature, as it is not currently stored (on purpose) in the config file.