### PR TITLE
Added --cache-dir option enabling user to provide a custom cache path…

### DIFF
--- a/dbxfs/main.py
+++ b/dbxfs/main.py
@@ -179,6 +179,7 @@ def _main(argv=None):
 
     access_token = None
     save_access_token = False
+    save_cache_dir = False
     save_config = False
 
     access_token_command = config.get("access_token_command", None)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="dbxfs",
-    version='1.0.39',
+    version='1.0.40',
     author="Rian Hunter",
     author_email="rian@alum.mit.edu",
     description="User-space file system for Dropbox",


### PR DESCRIPTION
… where dbxfs saves temporary file parts before saving them to mount_point

* cache-dir is automatically saved to config.json and reused on subsequent mounts
* if cache-dir does not exist or is not a directory, dbxfs falls back to its default cache dir